### PR TITLE
UI streamlining and translation scanner optimization

### DIFF
--- a/.github/workflows/duster-lint.yml
+++ b/.github/workflows/duster-lint.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Duster Lint"
-        uses: tighten/duster-action@v1
+        uses: tighten/duster-action@v2
         with:
           args: lint

--- a/src/Actions/SynchronizeAction.php
+++ b/src/Actions/SynchronizeAction.php
@@ -22,7 +22,7 @@ class SynchronizeAction extends Action
      */
     public static function synchronize(SynchronizeTranslationsCommand $command = null): array
     {
-        // extract all translation groups, keys and text
+        // Extract all translation groups, keys and text
         $groupsAndKeys = TranslationScanner::scan();
 
         $result = [];

--- a/src/Commands/SynchronizeTranslationsCommand.php
+++ b/src/Commands/SynchronizeTranslationsCommand.php
@@ -12,7 +12,7 @@ class SynchronizeTranslationsCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'translations:synchronize {--l|loud}';
+    protected $signature = 'translations:synchronize';
 
     /**
      * The console command description.
@@ -21,34 +21,29 @@ class SynchronizeTranslationsCommand extends Command
      */
     protected $description = 'Synchronize all application translations';
 
+    public function components()
+    {
+        return $this->components;
+    }
+
     /**
      * Execute the console command.
      */
     public function handle(): void
     {
         $startTime = microtime(true);
-        $this->info('Synchronization busy...');
+        $this->components->info('Starting synchronization.');
 
         $result = SynchronizeAction::synchronize($this);
+        $this->newLine();
 
-        $elapsedSecs = round(microtime(true) - $startTime, 2);
-        $this->info('Synchronization success! (' . $elapsedSecs . 's)');
-        $this->loudInfo('  - total: ' . $result['total_count']);
-        $this->loudInfo('  - deleted: ' . $result['deleted_count']);
-    }
+        $this->components->bulletList([
+            'synced translations: ' . $result['total_count'],
+            'purged translations: ' . $result['deleted_count'],
+        ]);
+        $this->newLine();
 
-    /**
-     * Prints the info message if loud option is enabled.
-     *
-     * @return void
-     */
-    public function loudInfo($message)
-    {
-        if (! $this->option('loud')) {
-            return;
-        }
-
-        $prefix = '[' . now()->format('H:i:s') . '] ! ';
-        $this->info($prefix . $message);
+        $runTime = number_format((microtime(true) - $startTime) * 1000, 0);
+        $this->components->info('Synchronization success! (' . $runTime . 'ms)');
     }
 }

--- a/src/Helpers/TranslationScanner.php
+++ b/src/Helpers/TranslationScanner.php
@@ -51,7 +51,7 @@ class TranslationScanner
      * @param  string  $groupName The name of the translation group.
      * @param  string|null  $parentKey The parent key path, if applicable.
      */
-    private static function parseTranslation($translationArray, $locale, $groupName, $parentKey = null): void
+    private static function parseTranslation(array $translationArray, string $locale, string $groupName, string|null $parentKey = null): void
     {
         foreach ($translationArray as $key => $value) {
             $currentKey = $parentKey ? $parentKey . '.' . $key : $key;
@@ -61,7 +61,7 @@ class TranslationScanner
             } else {
                 $found = false;
 
-                // check if the translation is already present and append it
+                // Check if the translation is already present and append it
                 foreach (self::$allGroupsAndKeys as &$groupAndKey) {
                     if ($groupAndKey['group'] === $groupName && $groupAndKey['key'] === $currentKey) {
                         $groupAndKey['text'][$locale] = $value;


### PR DESCRIPTION
This PR covers several updates:

1. The translation scanner process has been streamlined, so that the TranslationScanner now reads PHP files from the project directly and merges all discovered translations into $allGroupsAndKeys, which represents the LanguageLine table data in memory. Once this data is returned, any outdated translations are purged and the language lines are added to the table. Additionally, existing translations are now loaded into the database for improved efficiency.
2. The command-line user interface has been redesigned to match Laravel's modern look and feel. The amount of output has also been reduced to functional output only, improving the user experience.

![image](https://user-images.githubusercontent.com/865062/237060560-a2f84ccf-aeaa-4a6b-83b4-3ac202c92912.png)
