### PR TITLE
Option to hide translation groups

### DIFF
--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -16,7 +16,7 @@ return [
         ['code' => 'en', 'name' => 'English', 'flag' => 'gb'],
         // ['code' => 'nl', 'name' => 'Nederlands', 'flag' => 'nl'] ,
     ],
-
+    
     /*
     |--------------------------------------------------------------------------
     | Disable key and group editing

--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -50,5 +50,17 @@ return [
     */
 
     'navigation_group' => null,
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Hide translation groups
+    |--------------------------------------------------------------------------
+    |
+    | Hide selected translation groups from the listing. This is useful if you have
+    | multiple translation resources.
+    |
+    */
+
+    'hide_translation_groups' => [],
 
 ];

--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -16,7 +16,7 @@ return [
         ['code' => 'en', 'name' => 'English', 'flag' => 'gb'],
         // ['code' => 'nl', 'name' => 'Nederlands', 'flag' => 'nl'] ,
     ],
-    
+
     /*
     |--------------------------------------------------------------------------
     | Disable key and group editing
@@ -50,7 +50,7 @@ return [
     */
 
     'navigation_group' => null,
-    
+
     /*
     |--------------------------------------------------------------------------
     | Hide translation groups

--- a/src/Resources/LanguageLineResource.php
+++ b/src/Resources/LanguageLineResource.php
@@ -159,6 +159,15 @@ class LanguageLineResource extends Resource
         return Gate::allows('use-translation-manager');
     }
 
+    public static function getEloquentQuery(): Builder
+    {
+        if (! is_array(config('translation-manager.hide_translation_groups')) || count(config('translation-manager.hide_translation_groups')) == 0) {
+          return parent::getEloquentQuery()->whereNotIn('group', config('translation-manager.hide_translation_groups'));
+        }
+
+        return parent::getEloquentQuery();
+    }
+
     protected static function getNavigationLabel(): string
     {
         return __('translation-manager::translations.translation-navigation-label');
@@ -167,13 +176,5 @@ class LanguageLineResource extends Resource
     protected static function getNavigationGroup(): ?string
     {
         return config('translation-manager.navigation_group');
-    }
-
-    public static function getEloquentQuery(): Builder
-    {
-        if(!is_array(config('translation-manager.hide_translation_groups')) || count(config('translation-manager.hide_translation_groups')) == 0){
-          return parent::getEloquentQuery()->whereNotIn('group',config('translation-manager.hide_translation_groups'));
-        }
-        return parent::getEloquentQuery();
     }
 }

--- a/src/Resources/LanguageLineResource.php
+++ b/src/Resources/LanguageLineResource.php
@@ -168,4 +168,12 @@ class LanguageLineResource extends Resource
     {
         return config('translation-manager.navigation_group');
     }
+
+    public static function getEloquentQuery(): Builder
+    {
+        if(!is_array(config('translation-manager.hide_translation_groups')) || count(config('translation-manager.hide_translation_groups')) == 0){
+          return parent::getEloquentQuery()->whereNotIn('group',config('translation-manager.hide_translation_groups'));
+        }
+        return parent::getEloquentQuery();
+    }
 }


### PR DESCRIPTION
Hello
I had to make a page for dynamic translations which will create records on `language_lines` table. After i've made the page i noticed that the plugin shows the data i've created ... well.. expected that :)

So i went ahead and added an option to hide desired translation groups in case some other people use same methods as me.

Thank you.
