### PR TITLE
[Display] Express locales without flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,25 @@ Schema::create('language_lines', function (Blueprint $table) {
 
 Finally, run the migration.
 
+### Custom Theme Required
+
+In order to compile the package views currectly, we need to [create a custom Filament theme](https://filamentphp.com/docs/3.x/panels/themes#creating-a-custom-theme) **first**, and then add the following path to its content:
+
+```js
+// Located at: /resources/css/filament/admin/tailwind.config.js
+
+import preset from '../../../../vendor/filament/filament/tailwind.config.preset';
+
+export default {
+    presets: [preset],
+    content: [
+        // other content...
+        './vendor/kenepa/translation-manager/resources/**/*.blade.php',
+    ],
+};
+```
+
+
 ## Register the plugin with a panel
 
 ```php
@@ -80,6 +99,7 @@ Gate::define('use-translation-manager', function (?User $user) {
 });
 ```
 
+
 ## Configuration
 #### `available_locales`
 Determines which locales your application supports. For example:
@@ -95,9 +115,11 @@ Determines which locales your application supports. For example:
 Enable or disable the language switcher feature. This allows users to switch their language - disable if you have your own implementation.  
 ![Language Switcher](.github/language-switcher.png)
 
+
 ## Usage
 
 Once installed, the Translation Manager can be accessed via the Filament sidebar menu. Simply click on the "Translation Manager" link to access the translation management screen.
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Finally, run the migration.
 
 ### Custom Theme Required
 
-In order to compile the package views currectly, we need to [create a custom Filament theme](https://filamentphp.com/docs/3.x/panels/themes#creating-a-custom-theme) **first**, and then add the following path to its content:
+In order to compile the package views correctly, we need to [create a custom Filament theme](https://filamentphp.com/docs/3.x/panels/themes#creating-a-custom-theme) **first**, and then add the following path to its content:
 
 ```js
 // Located at: /resources/css/filament/admin/tailwind.config.js

--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -60,4 +60,15 @@ return [
 
     'navigation_group' => null,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Flags or Initials
+    |--------------------------------------------------------------------------
+    |
+    | Control whether to express locales using international flags, or through locale initial letters if disabled.
+    |
+    */
+
+    'show-flags' => true,
+
 ];

--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -65,7 +65,7 @@ return [
     | Flags or Initials
     |--------------------------------------------------------------------------
     |
-    | Control whether to express locales using international flags, or through locale initial letters if disabled.
+    | Control whether to express locales using international flags, or through locale initial letters if disabled in the language switcher.
     |
     */
 

--- a/resources/views/language-switcher.blade.php
+++ b/resources/views/language-switcher.blade.php
@@ -22,10 +22,11 @@ if(!function_exists('try_svg')) {
             $refs.panel.close(event)
         },
     }">
+    @php $showFlags = config('translation-manager.show-flags'); @endphp
     <button
         @class([
-            'ml-4 block hover:opacity-75', // TODO the extra?
-            'pt-2' => config('translation-manager.show-flags'),
+            'ml-4 block hover:opacity-75',
+            'pt-2' => $showFlags,
         ])
         id="filament-language-switcher"
         x-on:click="toggle"
@@ -33,12 +34,12 @@ if(!function_exists('try_svg')) {
         <div
             @class([
                 'flex items-center justify-center rounded-full bg-cover bg-center',
-                'w-10 h-10 bg-gray-200 dark:bg-gray-900' => config('translation-manager.show-flags'),
-                'w-[2.3rem] h-[2.3rem] bg-[#030712]' => !config('translation-manager.show-flags'),
+                'w-10 h-10 bg-gray-200 dark:bg-gray-900' => $showFlags,
+                'w-[2.3rem] h-[2.3rem] bg-[#030712]' => !$showFlags,
             ])
         >
             <span class="opacity-100">
-                @if (config('translation-manager.show-flags'))
+                @if ($showFlags)
                     {{ try_svg('flag-1x1-'.$currentLanguage['flag'], 'rounded-full w-10 h-10') }}
                 @else
                     <x-icon
@@ -65,7 +66,7 @@ if(!function_exists('try_svg')) {
                     @endif
                 >
                     <span class="filament-dropdown-list-item-label truncate w-full text-start flex justify-content-start gap-3">
-                        @if (config('translation-manager.testing'))
+                        @if ($showFlags)
                             {{ try_svg('flag-4x3-'.$language['flag'], 'w-6 h-6') }}
 
                             <span class="pl">{{ $language['name'] }}</span>

--- a/resources/views/language-switcher.blade.php
+++ b/resources/views/language-switcher.blade.php
@@ -22,7 +22,7 @@ if(!function_exists('try_svg')) {
             $refs.panel.close(event)
         },
     }">
-    @php $showFlags = config('translation-manager.show-flags'); @endphp
+
     <button
         @class([
             'ml-4 block hover:opacity-75',

--- a/resources/views/language-switcher.blade.php
+++ b/resources/views/language-switcher.blade.php
@@ -22,10 +22,30 @@ if(!function_exists('try_svg')) {
             $refs.panel.close(event)
         },
     }">
-    <button class="ml-4 pt-2" id="filament-language-switcher" class="block hover:opacity-75" x-on:click="toggle">
-        <div class="flex items-center justify-center w-10 h-10 rounded-full bg-gray-200 bg-cover bg-center dark:bg-gray-900">
+    <button
+        @class([
+            'ml-4 block hover:opacity-75', // TODO the extra?
+            'pt-2' => config('translation-manager.show-flags'),
+        ])
+        id="filament-language-switcher"
+        x-on:click="toggle"
+    >
+        <div
+            @class([
+                'flex items-center justify-center rounded-full bg-cover bg-center',
+                'w-10 h-10 bg-gray-200 dark:bg-gray-900' => config('translation-manager.show-flags'),
+                'w-[2.3rem] h-[2.3rem] bg-[#030712]' => !config('translation-manager.show-flags'),
+            ])
+        >
             <span class="opacity-100">
-                {{ try_svg('flag-1x1-'.$currentLanguage['flag'], 'rounded-full w-10 h-10') }}
+                @if (config('translation-manager.show-flags'))
+                    {{ try_svg('flag-1x1-'.$currentLanguage['flag'], 'rounded-full w-10 h-10') }}
+                @else
+                    <x-icon
+                        name="heroicon-o-language"
+                        class="w-5 h-5"
+                    />
+                @endif
             </span>
         </div>
     </button>
@@ -33,13 +53,27 @@ if(!function_exists('try_svg')) {
     <div x-ref="panel" x-float.placement.bottom-end.flip.offset="{ offset: 8 }" x-transition:enter-start="opacity-0 scale-95" x-transition:leave-end="opacity-0 scale-95" class="ffi-dropdown-panel absolute z-10 w-screen divide-y divide-gray-100 rounded-lg bg-white shadow-lg ring-1 ring-gray-950/5 transition dark:divide-white/5 dark:bg-gray-900 dark:ring-white/10 max-w-[14rem]" style="display: none; left: 1152px; top: 59.5px;">
         <div class="filament-dropdown-list p-1">
             @foreach ($otherLanguages as $language)
-            <a class="filament-dropdown-list-item filament-dropdown-item group flex w-full items-center whitespace-nowrap rounded-md p-2 text-sm outline-none hover:bg-gray-50 focus:bg-gray-50 dark:hover:bg-white/5 dark:focus:bg-white/5 text-gray-500 hover:text-gray-700 focus:text-gray-500 dark:text-gray-200 dark:hover:text-gray-200 dark:focus:text-gray-400" href="{{ route('translation-manager.switch', ['code' => $language['code']]) }}">
-                <span class="filament-dropdown-list-item-label truncate w-full text-start flex justify-content-start gap-3">
-                    {{ try_svg('flag-4x3-'.$language['flag'], 'w-6 h-6') }}
+                @php $isCurrent = $currentLanguage['code'] === $language['code']; @endphp
+                <a
+                    @class([
+                        'filament-dropdown-list-item filament-dropdown-item group flex w-full items-center whitespace-nowrap rounded-md p-2 text-sm outline-none text-gray-500 dark:text-gray-200',
+                        'hover:bg-gray-50 focus:bg-gray-50 dark:hover:bg-white/5 dark:focus:bg-white/5 hover:text-gray-700 focus:text-gray-500 dark:hover:text-gray-200 dark:focus:text-gray-400' => !$isCurrent,
+                        'cursor-default' => $isCurrent,
+                    ])
+                    @if (!$isCurrent)
+                        href="{{ route('translation-manager.switch', ['code' => $language['code']]) }}"
+                    @endif
+                >
+                    <span class="filament-dropdown-list-item-label truncate w-full text-start flex justify-content-start gap-3">
+                        @if (config('translation-manager.testing'))
+                            {{ try_svg('flag-4x3-'.$language['flag'], 'w-6 h-6') }}
 
-                    <span class="pl">{{ $language['name'] }}</span>
-                </span>
-            </a>
+                            <span class="pl">{{ $language['name'] }}</span>
+                        @else
+                            <span @class(['font-semibold' => $isCurrent])>{{ str($language['code'])->upper()->value() . " - {$language['name']}" }}</span>
+                        @endif
+                    </span>
+                </a>
             @endforeach
         </div>
     </div>

--- a/src/TranslationManagerPlugin.php
+++ b/src/TranslationManagerPlugin.php
@@ -59,9 +59,13 @@ class TranslationManagerPlugin implements Plugin
         $locales = config('translation-manager.available_locales');
         $currentLocale = app()->getLocale();
         $currentLanguage = collect($locales)->firstWhere('code', $currentLocale);
-
         $otherLanguages = $locales;
+        $showFlags = config('translation-manager.show-flags');
 
-        return view('translation-manager::language-switcher', compact('otherLanguages', 'currentLanguage'));
+        return view('translation-manager::language-switcher', compact(
+            'otherLanguages',
+            'currentLanguage',
+            'showFlags',
+        ));
     }
 }


### PR DESCRIPTION
- Added a config to control the option
- Inherited the styles from the default avatar
- Added a missing section on how custom Tailwind styling works in README
- Accounted for the current locale
- Displayed a heroicon by default for the switcher when flags are off
- Displayed locale initials (codes) instead of flags in the dropdown