### PR TITLE
Fix default value for text in the migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Schema::create('language_lines', function (Blueprint $table) {
     $table->bigIncrements('id');
     $table->string('group')->index();
     $table->string('key')->index();
-    $table->json('text')->default('[]');
+    $table->json('text')->default(new \Illuminate\Database\Query\Expression('(JSON_ARRAY())'));
     $table->timestamps();
 });
 ```


### PR DESCRIPTION
Fixes SQLSTATE[42000]: Syntax error or access violation: 1101 BLOB, TEXT, GEOMETRY or JSON column 'text' can't have a default value