### PR TITLE
[Critical] Fix Filament new Page method

### DIFF
--- a/src/Pages/QuickTranslate.php
+++ b/src/Pages/QuickTranslate.php
@@ -23,7 +23,10 @@ class QuickTranslate extends Page implements HasForms
     public $totalLanguageLines;
     public $enteredTranslation;
 
-    public static function shouldRegisterNavigation(): bool
+    /**
+     * @param  array<string, mixed>  $parameters
+     */
+    public static function shouldRegisterNavigation(array $parameters = []): bool
     {
         return config('translation-manager.quick_translate_navigation_registration');
     }


### PR DESCRIPTION
- Update the shouldRegisterNavigation properties

This update is observed in Filament's [/Resources/Pages/Page.php](https://github.com/filamentphp/filament/blob/96ed07b926970a2a0b6a93f8fdb24288a2352a03/packages/panels/src/Resources/Pages/Page.php#L130C1-L130C1).

> [!WARNING]<br>This bug is breaking PHP and preventing Composer workflow.