### PR TITLE
Use LanguageLine from config

### DIFF
--- a/src/Actions/SynchronizeAction.php
+++ b/src/Actions/SynchronizeAction.php
@@ -29,8 +29,11 @@ class SynchronizeAction extends Action
         $result = [];
         $result['total_count'] = 0;
 
+        /** @var LanguageLine $languageLine */
+        $languageLine = config('translation-loader.model', LanguageLine::class);
+
         // Find and delete old LanguageLines that no longer exist in the translation files
-        $result['deleted_count'] = LanguageLine::query()
+        $result['deleted_count'] = $languageLine::query()
             ->whereNotIn('group', array_column($groupsAndKeys, 'group'))
             ->orWhereNotIn('key', array_column($groupsAndKeys, 'key'))
             ->delete();
@@ -39,12 +42,12 @@ class SynchronizeAction extends Action
         foreach ($groupsAndKeys as $groupAndKey) {
             $startTime = microtime(true);
 
-            $existingItem = LanguageLine::where('group', $groupAndKey['group'])
+            $existingItem = $languageLine::where('group', $groupAndKey['group'])
                 ->where('key', $groupAndKey['key'])
                 ->first();
 
             if (! $existingItem) {
-                LanguageLine::create([
+                $languageLine::create([
                     'group' => $groupAndKey['group'],
                     'key' => $groupAndKey['key'],
                     'text' => $groupAndKey['text'],

--- a/src/Pages/QuickTranslate.php
+++ b/src/Pages/QuickTranslate.php
@@ -101,16 +101,16 @@ class QuickTranslate extends Page implements HasForms
      */
     public function next(): void
     {
-        $this->record = LanguageLine::whereNull('text->' . $this->selectedLocale)
+        $this->record = static::getModel()::whereNull('text->' . $this->selectedLocale)
             ->first();
 
-        $this->totalLanguageLines = LanguageLine::whereNull('text->' . $this->selectedLocale)->count();
+        $this->totalLanguageLines = static::getModel()::whereNull('text->' . $this->selectedLocale)->count();
     }
 
     public function skip(): void
     {
         $this->offset++;
-        $this->record = LanguageLine::whereNull('text->' . $this->selectedLocale)
+        $this->record = static::getModel()::whereNull('text->' . $this->selectedLocale)
             ->offset($this->offset)
             ->first();
     }

--- a/src/Resources/LanguageLineResource.php
+++ b/src/Resources/LanguageLineResource.php
@@ -28,9 +28,13 @@ use Spatie\TranslationLoader\LanguageLine;
 class LanguageLineResource extends Resource
 {
     use CanRegisterPanelNavigation;
-    protected static ?string $model = LanguageLine::class;
     protected static ?string $navigationIcon = 'heroicon-o-globe-alt';
     protected static ?string $slug = 'translation-manager';
+
+    public static function getModel(): string
+    {
+        return config('translation-loader.model', LanguageLine::class);
+    }
 
     /**
      * @param  array<string, mixed>  $parameters


### PR DESCRIPTION
Some people might override the default model and use a custom one. This PR remove the usage of hardcoded LanguageLine model, but instead use dynamic value from spatie/translation-loader config. 

Feel free to drop or accept this PR, thank you.