### PR TITLE
Fix data truncated by ensuring keys are strings.

### DIFF
--- a/resources/lang/en/translations.php
+++ b/resources/lang/en/translations.php
@@ -14,6 +14,7 @@ return [
     'add-translation-button' => 'Add new translation',
     'translation-language' => 'Language',
     'translation-text' => 'Translated text',
+    'translation-section' => 'Translations',
     'filter-not-translated' => 'Not translated into',
     'quick-translate' => 'Quick Translate',
     'quick-translate-select-locale' => 'Select the language',

--- a/resources/lang/nl/translations.php
+++ b/resources/lang/nl/translations.php
@@ -14,6 +14,7 @@ return [
     'add-translation-button' => 'Voeg nieuwe vertaling toe',
     'translation-language' => 'Taal',
     'translation-text' => 'Vertaalde tekst',
+    'translation-section' => 'Vertalingen',
     'filter-not-translated' => 'Niet vertaald naar',
     'quick-translate' => 'Snelle vertaling',
     'quick-translate-select-locale' => 'Selecteer de taal',

--- a/src/Helpers/TranslationScanner.php
+++ b/src/Helpers/TranslationScanner.php
@@ -61,6 +61,7 @@ class TranslationScanner
     private static function parseTranslation(array $translationArray, string $locale, string $groupName, string $parentKey = null): void
     {
         foreach ($translationArray as $key => $value) {
+            $key = (string) $key;
             $currentKey = $parentKey ? $parentKey . '.' . $key : $key;
 
             if (is_array($value)) {

--- a/src/Resources/LanguageLineResource.php
+++ b/src/Resources/LanguageLineResource.php
@@ -71,7 +71,7 @@ class LanguageLineResource extends Resource
                     ->disabled()
                     ->columnSpan(2),
 
-                Section::make('Translations')->schema([
+                Section::make(__('translation-manager::translations.translation-section'))->schema([
                     Repeater::make('translations')->schema([
                         Select::make('language')
                             ->prefixIcon('heroicon-o-language')


### PR DESCRIPTION
Currently in our app, whenever we try to synchronize translations, we get SQL error due to incorrect data types. Turns out whenever an array key is a numeric value in the translations file, the `parseTranslation` function doesn't work correctly. This is an issue when translating `http-statuses`:

```php
return [
    '0'   => 'Unknown Error',
    '100' => 'Continue',
    '101' => 'Switching Protocols',
    // ...
];
```

The above keys would turn into integers which causes issues in the DELETE query for the synchronize action. Rather than fixing that query and having to potentially figure out more queries where this goes wrong, instead this ensures the keys are always strings to begin with, avoiding the issue altogether.

As a small bonus fix, add a missing translation key for the `Section` in the resource.