### PR TITLE
Fix language switcher and PanelNavigation bug

### DIFF
--- a/resources/views/language-switcher.blade.php
+++ b/resources/views/language-switcher.blade.php
@@ -34,13 +34,13 @@ if(!function_exists('try_svg')) {
         <div
             @class([
                 'flex items-center justify-center rounded-full bg-cover bg-center',
-                'w-10 h-10 bg-gray-200 dark:bg-gray-900' => $showFlags,
+                'w-8 h-8 bg-gray-200 dark:bg-gray-900' => $showFlags,
                 'w-[2.3rem] h-[2.3rem] bg-[#030712]' => !$showFlags,
             ])
         >
             <span class="opacity-100">
                 @if ($showFlags)
-                    {{ try_svg('flag-1x1-'.$currentLanguage['flag'], 'rounded-full w-10 h-10') }}
+                    {{ try_svg('flag-1x1-'.$currentLanguage['flag'], 'rounded-full w-8 h-8') }}
                 @else
                     <x-icon
                         name="heroicon-o-language"

--- a/resources/views/language-switcher.blade.php
+++ b/resources/views/language-switcher.blade.php
@@ -25,7 +25,7 @@ if(!function_exists('try_svg')) {
 
     <button
         @class([
-            'ml-4 block hover:opacity-75',
+            'block hover:opacity-75',
             'pt-0' => $showFlags,
         ])
         id="filament-language-switcher"

--- a/src/Traits/CanRegisterPanelNavigation.php
+++ b/src/Traits/CanRegisterPanelNavigation.php
@@ -12,10 +12,11 @@ trait CanRegisterPanelNavigation
             return true;
         }
 
-        foreach (config('translation-manager.dont_register_navigation_on_panel_ids') as $panelName) {
-            if (Filament::getCurrentPanel()->getId() === $panelName) {
-                return false;
-            }
+        if (in_array(
+            Filament::getCurrentPanel()->getId(),
+            config('translation-manager.dont_register_navigation_on_panel_ids')
+        )) {
+            return false;
         }
 
         return true;

--- a/src/Traits/CanRegisterPanelNavigation.php
+++ b/src/Traits/CanRegisterPanelNavigation.php
@@ -13,7 +13,7 @@ trait CanRegisterPanelNavigation
         }
 
         foreach (config('translation-manager.dont_register_navigation_on_panel_ids') as $panelName) {
-            if (Filament::getPanel()->getId() === $panelName) {
+            if (Filament::getCurrentPanel()->getId() === $panelName) {
                 return false;
             }
         }


### PR DESCRIPTION
This PR fixes two bugs:

- It fixes `CanRegisterPanelNavigation` to restrict access for `LanguageLineResource` for specified panels. 
- It updates `language-switcher.blade.php` to match the language switcher icon size with Filament and remove unnecessary margin left.