### PR TITLE
[4.x] feat: add missing translation for the Translations section header

### DIFF
--- a/resources/lang/ar/translations.php
+++ b/resources/lang/ar/translations.php
@@ -12,6 +12,7 @@ return [
     'preview' => 'Preview',
     'preview-description' => 'هذا مثال باللغة المحددة حاليًا (:lang)',
     'add-translation-button' => 'إضافة ترجمة جديدة',
+    'translations-header' => 'الترجمات',
     'translation-language' => 'لغة',
     'translation-text' => 'نص مترجم',
     'filter-not-translated' => 'لم تترجم إلى',

--- a/resources/lang/ca/translations.php
+++ b/resources/lang/ca/translations.php
@@ -12,6 +12,7 @@ return [
     'preview' => 'Previsualitzar',
     'preview-description' => 'Es un exemple en la teva llegua (:lang)',
     'add-translation-button' => 'Afegir traducció',
+    'translations-header' => 'Traduccions',
     'translation-language' => 'Llengua',
     'translation-text' => 'Text traduït',
     'filter-not-translated' => 'No traduït al ',

--- a/resources/lang/de/translations.php
+++ b/resources/lang/de/translations.php
@@ -12,6 +12,7 @@ return [
     'preview' => 'Vorschau',
     'preview-description' => 'Dies ist eine Vorschau in der aktuellen ausgewählten Sprache (:lang)',
     'add-translation-button' => 'Neue Übersetzung hinzufügen',
+    'translations-header' => 'Übersetzungen',
     'translation-language' => 'Sprache',
     'translation-text' => 'Übersetzter Text',
     'filter-not-translated' => 'Nicht übersetzt in',

--- a/resources/lang/en/translations.php
+++ b/resources/lang/en/translations.php
@@ -12,6 +12,7 @@ return [
     'preview' => 'Preview',
     'preview-description' => 'This is an example in the currently selected language (:lang)',
     'add-translation-button' => 'Add new translation',
+    'translations-header' => 'Translations',
     'translation-language' => 'Language',
     'translation-text' => 'Translated text',
     'filter-not-translated' => 'Not translated into',

--- a/resources/lang/es/translations.php
+++ b/resources/lang/es/translations.php
@@ -12,6 +12,7 @@ return [
     'preview' => 'Previsualizar',
     'preview-description' => 'Es es un ejemplo en tu idioma (:lang)',
     'add-translation-button' => 'Añadir traducción',
+    'translations-header' => 'Traducciones',
     'translation-language' => 'Idioma',
     'translation-text' => 'Texto traducido',
     'filter-not-translated' => 'No traducido al ',

--- a/resources/lang/fr/translations.php
+++ b/resources/lang/fr/translations.php
@@ -12,6 +12,7 @@ return [
     'preview' => 'Aperçu',
     'preview-description' => 'Ceci est un aperçu dans la langue actuellement sélectionnée (:lang)',
     'add-translation-button' => 'Ajouter une nouvelle traduction',
+    'translations-header' => 'Traductions',
     'translation-language' => 'Langue',
     'translation-text' => 'Texte traduit',
     'filter-not-translated' => 'Non traduit en',

--- a/resources/lang/nl/translations.php
+++ b/resources/lang/nl/translations.php
@@ -12,6 +12,7 @@ return [
     'preview' => 'Voorbeeld',
     'preview-description' => 'Dit is een voorbeeld in de huidige geselecteerde taal (:lang)',
     'add-translation-button' => 'Voeg nieuwe vertaling toe',
+    'translations-header' => 'Vertalingen',
     'translation-language' => 'Taal',
     'translation-text' => 'Vertaalde tekst',
     'filter-not-translated' => 'Niet vertaald naar',

--- a/resources/lang/tr/translations.php
+++ b/resources/lang/tr/translations.php
@@ -12,6 +12,7 @@ return [
     'preview' => 'Ön İzleme',
     'preview-description' => 'Aktif olan dil üzerinde nasıl görünecek (:lang)',
     'add-translation-button' => 'Yeni çeviri ekle',
+    'translations-header' => 'Çeviriler',
     'translation-language' => 'Dil',
     'translation-text' => 'Çevirilen terim',
     'filter-not-translated' => 'Çevirisi eksik olan',

--- a/src/Resources/LanguageLineResource.php
+++ b/src/Resources/LanguageLineResource.php
@@ -71,7 +71,7 @@ class LanguageLineResource extends Resource
                     ->disabled()
                     ->columnSpan(2),
 
-                Section::make('Translations')->schema([
+                Section::make(__('translation-manager::translations.translations-header'))->schema([
                     Repeater::make('translations')->schema([
                         Select::make('language')
                             ->prefixIcon('heroicon-o-language')


### PR DESCRIPTION
This PR introduces the missing translation for the "Translations" section header.