### PR TITLE
[4.x] Feat translations repeater

### DIFF
--- a/src/Resources/LanguageLineResource.php
+++ b/src/Resources/LanguageLineResource.php
@@ -78,17 +78,25 @@ class LanguageLineResource extends Resource
                             ->label(__('translation-manager::translations.translation-language'))
                             ->options(collect(config('translation-manager.available_locales'))->pluck('code', 'code'))
                             ->disableOptionsWhenSelectedInSiblingRepeaterItems()
+                            ->columnSpanFull()
                             ->required(),
 
                         Textarea::make('text')
                             ->label(__('translation-manager::translations.translation-text'))
+                            ->columnSpanFull()
                             ->required(),
                     ])->columns(2)
                         ->addActionLabel(__('translation-manager::translations.add-translation-button'))
                         ->hiddenLabel()
                         ->defaultItems(0)
                         ->reorderable(false)
-                        ->grid(2)
+                        ->grid([
+                            'default' => 1,
+                            'sm' => 1,
+                            'md' => 2,
+                            'xl' => 3,
+                            '2xl' => 4,
+                        ])
                         ->columnSpan(2)
                         ->maxItems(count(config('translation-manager.available_locales'))),
                 ]),

--- a/src/Resources/LanguageLineResource.php
+++ b/src/Resources/LanguageLineResource.php
@@ -77,6 +77,7 @@ class LanguageLineResource extends Resource
                             ->prefixIcon('heroicon-o-language')
                             ->label(__('translation-manager::translations.translation-language'))
                             ->options(collect(config('translation-manager.available_locales'))->pluck('code', 'code'))
+                            ->disableOptionsWhenSelectedInSiblingRepeaterItems()
                             ->required(),
 
                         Textarea::make('text')

--- a/src/Resources/LanguageLineResource.php
+++ b/src/Resources/LanguageLineResource.php
@@ -76,7 +76,7 @@ class LanguageLineResource extends Resource
                         Select::make('language')
                             ->prefixIcon('heroicon-o-language')
                             ->label(__('translation-manager::translations.translation-language'))
-                            ->options(collect(config('translation-manager.available_locales'))->pluck('code', 'code'))
+                            ->options(collect(config('translation-manager.available_locales'))->pluck('name', 'code'))
                             ->disableOptionsWhenSelectedInSiblingRepeaterItems()
                             ->columnSpanFull()
                             ->required(),


### PR DESCRIPTION
This PR introduces some minor fixes to the Repeater in the LanguageLine Resource:

- Disable the language in the select if it has already been used an another element
- Use the name, instead of the code as the language option label
- Use a more pleasant grid layout (with language and translation on separate lines) for the repeater