### PR TITLE
feat: restrict deleting translations to permission `admin-translation-manager`

### DIFF
--- a/resources/views/preview-translation.blade.php
+++ b/resources/views/preview-translation.blade.php
@@ -2,6 +2,6 @@
     <h3 class="text-lg font-bold mb-2">{{ __('translation-manager::translations.preview') }}</h3>
     <p class="text-sm text-gray-600 dark:text-white mb-4">{{ __('translation-manager::translations.preview-description', ['lang' => app()->getLocale()]) }}</p>
     <div class="bg-white p-6 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 rounded-lg">
-        <p class="text-base text-gray-800">{{ trans($this->record->group . '.' . $this->record->key) }}</p>
+        <p class="text-base">{{ trans($this->record->group . '.' . $this->record->key) }}</p>
     </div>
 </div>

--- a/src/Resources/LanguageLineResource.php
+++ b/src/Resources/LanguageLineResource.php
@@ -98,6 +98,7 @@ class LanguageLineResource extends Resource
                             '2xl' => 4,
                         ])
                         ->columnSpan(2)
+                        ->deletable(Gate::allows('admin-translation-manager'))
                         ->maxItems(count(config('translation-manager.available_locales'))),
                 ]),
             ]);

--- a/src/Resources/LanguageLineResource/Pages/ListLanguageLines.php
+++ b/src/Resources/LanguageLineResource/Pages/ListLanguageLines.php
@@ -37,7 +37,8 @@ class ListLanguageLines extends ListRecords
                 ->url(LanguageLineResource::getUrl('quick-translate')),
 
             SynchronizeAction::make('synchronize')
-                ->action('synchronize'),
+                ->action('synchronize')
+                ->visible(app('Illuminate\Contracts\Auth\Access\Gate')->allows('admin-translation-manager')),
         ];
     }
 }


### PR DESCRIPTION
Restricts the ability to delete repeater items for translations to a new gate permission `admin-translation-manager`

This means that users without this gate permission in AppServiceProvider can see the manager page, but cannot delete existing translations.

Additionally only people with this admin gate permission can synchronise, and also removed unnecessary CSS class which caused dark mode issues
