### PR TITLE
fix: ensure translation key is a string

### DIFF
--- a/src/Helpers/TranslationScanner.php
+++ b/src/Helpers/TranslationScanner.php
@@ -61,7 +61,8 @@ class TranslationScanner
     private static function parseTranslation(array $translationArray, string $locale, string $groupName, ?string $parentKey = null): void
     {
         foreach ($translationArray as $key => $value) {
-            $currentKey = $parentKey ? $parentKey . '.' . $key : $key;
+            // Ensure that $currentKey is a string as it will otherwise create errors with Eloquent
+            $currentKey = (string) ($parentKey ? $parentKey . '.' . $key : $key);
 
             if (is_array($value)) {
                 self::parseTranslation($value, $locale, $groupName, $currentKey);


### PR DESCRIPTION
If a keys on the first level in a lang file is a number, it will be coerced to a int or float which causes exceptions for some queries.

### Replication:

1. Create a lang file with numbers on the first level, e.g.:

```
return [
    '0'            => 'Unknown Error',
    '100'          => 'Continue',
    '101'          => 'Switching Protocols',
    '102'          => 'Processing',
    '200'          => 'OK',
];
```
2. Run `php artisan translations:synchronize` which works
3. Run `php artisan translations:synchronize` again which should result in an exception like this:
<img width="1736" height="216" alt="image" src="https://github.com/user-attachments/assets/c0ce29b5-5e5d-472e-abd2-835e5bf21107" />
