### PR TITLE
fix: hasTopbar() call when used outside panels

### DIFF
--- a/resources/views/language-switcher.blade.php
+++ b/resources/views/language-switcher.blade.php
@@ -10,7 +10,7 @@
         }
     }
 
-    $isInSideBar = !Filament::getCurrentPanel()->hasTopbar()
+    $isInSideBar = !Filament::getCurrentPanel()?->hasTopbar()
 @endphp
 
 <x-filament::dropdown placement="bottom-start">


### PR DESCRIPTION
This pull requests add null safe operator for `hasTopbar()` call to avoid an exception when used outside of Filament panels.

