### PR TITLE
feat: add Azerbaijani translations

### DIFF
--- a/resources/lang/az/translations.php
+++ b/resources/lang/az/translations.php
@@ -1,0 +1,26 @@
+<?php
+
+return [
+    'translation-navigation-label' => 'Tərcümə Meneceri',
+    'translation-label' => 'Tərcümə|Tərcümələr',
+    'group' => 'Tərcümə qrupu',
+    'key' => 'Tərcümə açarı',
+    'preview-in-your-lang' => 'Cari dilinizdə önizləmə (:lang)',
+    'synchronize' => 'Sinxronizasiya et',
+    'synchronization-success' => ':count tərcümə sinxronizasiya edildi!',
+    'synchronization-deleted' => ':count istifadə olunmayan tərcümə silindi',
+    'preview' => 'Önizləmə',
+    'preview-description' => 'Bu, hazırda seçilmiş dil (:lang) üçün nümunədir',
+    'add-translation-button' => 'Yeni tərcümə əlavə et',
+    'translations-header' => 'Tərcümələr',
+    'translation-language' => 'Dil',
+    'translation-text' => 'Tərcümə mətni',
+    'filter-not-translated' => 'Bu dilə tərcümə olunmayıb',
+    'quick-translate' => 'Sürətli Tərcümə',
+    'quick-translate-select-locale' => 'Dili seçin',
+    'quick-translate-translation-number' => 'Tərcümə edilməli :total tərcümə qalıb',
+    'quick-translate-skip' => 'Bu tərcüməni keç',
+    'quick-translate-enter' => '":lang" dilində tərcüməni daxil edin:',
+    'quick-translate-save-and-continue' => 'Yadda saxla və davam et',
+    'quick-translate-nothing' => 'Tərcümə ediləcək heç nə qalmayıb!',
+];


### PR DESCRIPTION
## Summary

This PR adds Azerbaijani (`az`) translations for the Translation Manager interface.

## Changes

* Added Azerbaijani translations for all existing translation strings.
* Preserved existing translation keys and placeholders (`:lang`, `:count`, `:total`).
* Used terminology consistent with common Azerbaijani localization practices.

## Testing

* Verified that all translation keys are present.
* Confirmed that placeholders remain unchanged and work correctly.